### PR TITLE
Update CI actions and Node.js versions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,14 +5,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [20.x, 22.x, 24.x]
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Cache Node.js modules
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/node_modules
         key: ${{ runner.OS }}-${{ matrix.node-version}}-node_modules-${{ hashFiles('yarn.lock') }}
@@ -20,10 +20,9 @@ jobs:
     - run: yarn test --coverage
     - name: Create coverage report flag
       id: codecov-flag
-      run: echo "::set-output name=flag::node_${NODE_VERSION/./_}"
+      run: echo "flag=node_${NODE_VERSION/./_}" >> "$GITHUB_OUTPUT"
       env:
         NODE_VERSION: ${{ matrix.node-version }}
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v5
       with:
         flags: ${{ steps.codecov-flag.outputs.flag }}
-


### PR DESCRIPTION
Why
===
CI is broken because `actions/cache@v2` has been sunset by GitHub. The other actions are also outdated, `::set-output` is deprecated, and Node 16 is EOL.

How
===
Update `actions/checkout` (v2 to v4), `actions/setup-node` (v2 to v4), `actions/cache` (v2 to v4), and `codecov/codecov-action` (v1 to v5). Replace `::set-output` with `$GITHUB_OUTPUT`. Update the Node.js test matrix from 16.x to 20.x, 22.x, and 24.x.

Test Plan
===
CI should pass on the PR with all three Node versions.